### PR TITLE
Rename featured-image class to post-featured-image

### DIFF
--- a/templates/styles.css
+++ b/templates/styles.css
@@ -517,9 +517,9 @@ article h1 {
         padding-left: 36px;
     }
 
-    .featured-image {
+    .post-featured-image {
         float: right;
-        margin: 10px;
+        margin: 10px 0px 10px 10px;
         width: 50%;
     }
 }


### PR DESCRIPTION
For for issues introduced in #124 after testing.

This pull request makes a minor update to the CSS class for featured images in articles. The class name is changed from `.featured-image` to `.post-featured-image`, and the margin property is adjusted to provide more consistent spacing.

- Renamed the CSS class from `.featured-image` to `.post-featured-image` and updated the margin values for improved layout.